### PR TITLE
Add support to Context Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Support to Context Parameters
+
 ### Changed
 
 ### Deprecated

--- a/kotlin-stdlib/build.gradle.kts
+++ b/kotlin-stdlib/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.javiersc.gradle.properties.extensions.getBooleanProperty
+import org.jetbrains.kotlin.gradle.internal.config.LanguageFeature
 
 hubdle {
     config {
@@ -11,6 +12,7 @@ hubdle {
         publishing()
         languageSettings { //
             experimentalContracts()
+            enableLanguageFeatures(LanguageFeature.ContextParameters)
         }
     }
     kotlin {


### PR DESCRIPTION
This pull request adds support for Kotlin Context Parameters in the project. The most important changes include updating the build configuration to enable the Context Parameters language feature and documenting this addition in the changelog.

**Kotlin language feature support:**

* Enabled the `ContextParameters` language feature in the `languageSettings` block of `kotlin-stdlib/build.gradle.kts`.
* Imported `LanguageFeature` from `org.jetbrains.kotlin.gradle.internal.config` to allow enabling specific Kotlin language features.

**Documentation:**

* Added an entry to `CHANGELOG.md` to note the support for Context Parameters.